### PR TITLE
Implement UI pages per design

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "axios": "^1.6.2",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React from 'react';
+import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Layout from './components/Layout';
+import CSVImport from './pages/CSVImport';
+import CSVExport from './pages/CSVExport';
+import DatabaseManager from './pages/DatabaseManager';
+import Logs from './pages/Logs';
 
 function App() {
-  const [csvData, setCsvData] = useState([]);
-
-  useEffect(() => {
-    axios.get('/wp-json/reactdb/v1/csv/read')
-      .then(res => setCsvData(res.data))
-      .catch(err => console.error(err));
-  }, []);
-
   return (
-    <div>
-      <h1>CSV Data</h1>
-      <pre>{JSON.stringify(csvData, null, 2)}</pre>
-    </div>
+    <Router>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Navigate to="/import" />} />
+          <Route path="/import" element={<CSVImport />} />
+          <Route path="/export" element={<CSVExport />} />
+          <Route path="/db" element={<DatabaseManager />} />
+          <Route path="/logs" element={<Logs />} />
+        </Routes>
+      </Layout>
+    </Router>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const title = screen.getByText(/React DB Manager/i);
+  expect(title).toBeInTheDocument();
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Header = () => (
+  <header className="bg-gray-800 text-white flex justify-between items-center p-4">
+    <h1 className="text-xl font-bold">React DB Manager</h1>
+    <div>
+      <span className="mr-2">Admin</span>
+      <button className="bg-gray-700 px-2 py-1 rounded">Logout</button>
+    </div>
+  </header>
+);
+
+export default Header;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Header from './Header';
+import Sidebar from './Sidebar';
+
+const Layout = ({ children }) => (
+  <div className="min-h-screen flex flex-col">
+    <Header />
+    <div className="flex flex-1">
+      <Sidebar />
+      <main className="flex-1 p-4">{children}</main>
+    </div>
+  </div>
+);
+
+export default Layout;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const linkClass = 'block py-2 px-4 hover:bg-gray-200';
+
+const Sidebar = () => (
+  <aside className="bg-gray-100 w-48 min-h-screen">
+    <nav>
+      <NavLink className={linkClass} to="/import">CSVインポート</NavLink>
+      <NavLink className={linkClass} to="/export">CSVエクスポート</NavLink>
+      <NavLink className={linkClass} to="/db">データベース一覧</NavLink>
+      <NavLink className={linkClass} to="/logs">操作ログ</NavLink>
+    </nav>
+  </aside>
+);
+
+export default Sidebar;

--- a/src/pages/CSVExport.js
+++ b/src/pages/CSVExport.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+const CSVExport = () => {
+  const [downloadUrl, setDownloadUrl] = useState('');
+
+  const handleExport = () => {
+    // placeholder for export logic
+    setDownloadUrl('/path/to/export.csv');
+  };
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">CSVエクスポート</h2>
+      <select className="border p-2 mb-4">
+        <option>テーブルを選択</option>
+      </select>
+      <button onClick={handleExport} className="bg-blue-500 text-white px-4 py-2 rounded">
+        エクスポート
+      </button>
+      {downloadUrl && (
+        <div className="mt-4">
+          <a href={downloadUrl} download className="text-blue-600 underline">
+            ダウンロード
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CSVExport;

--- a/src/pages/CSVImport.js
+++ b/src/pages/CSVImport.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+const CSVImport = () => {
+  const [log, setLog] = useState('');
+
+  const handleUpload = () => {
+    // placeholder for upload logic
+    setLog('アップロードしました');
+  };
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold mb-4">CSVインポート</h2>
+      <div className="border-dashed border-2 p-8 text-center mb-4">
+        <input type="file" accept=".csv" />
+      </div>
+      <button onClick={handleUpload} className="bg-blue-500 text-white px-4 py-2 rounded">
+        アップロード
+      </button>
+      {log && <div className="mt-4">{log}</div>}
+    </div>
+  );
+};
+
+export default CSVImport;

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const DatabaseManager = () => (
+  <div className="flex">
+    <div className="w-1/4 pr-4 border-r">
+      <h2 className="font-bold mb-2">テーブル一覧</h2>
+      <ul>
+        <li>sample_table</li>
+      </ul>
+    </div>
+    <div className="w-3/4 pl-4">
+      <h2 className="font-bold mb-2">テーブル内容</h2>
+      <p>ここに選択したテーブルの内容を表示します。</p>
+    </div>
+  </div>
+);
+
+export default DatabaseManager;

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const Logs = () => (
+  <div>
+    <h2 className="text-lg font-bold mb-4">操作ログ</h2>
+    <table className="min-w-full border">
+      <thead>
+        <tr className="bg-gray-200">
+          <th className="px-2 py-1 border">日時</th>
+          <th className="px-2 py-1 border">ユーザー</th>
+          <th className="px-2 py-1 border">操作内容</th>
+          <th className="px-2 py-1 border">詳細</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td className="border px-2 py-1">-</td>
+          <td className="border px-2 py-1">-</td>
+          <td className="border px-2 py-1">-</td>
+          <td className="border px-2 py-1">-</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+);
+
+export default Logs;


### PR DESCRIPTION
## Summary
- add routing and skeleton pages
- implement header, sidebar, layout components
- include CSV Import/Export, DB Manager, Logs pages
- update tests to check header title
- add missing dependencies

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88f60e808323b3f46f1d1b29502f