### PR TITLE
Refine UI pages with Material UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "axios": "^1.6.2",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.4.1",
+    "@mui/material": "^5.15.13",
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React from 'react';
+import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import Layout from './components/Layout';
+import CSVImport from './pages/CSVImport';
+import CSVExport from './pages/CSVExport';
+import DatabaseManager from './pages/DatabaseManager';
+import Logs from './pages/Logs';
 
 function App() {
-  const [csvData, setCsvData] = useState([]);
-
-  useEffect(() => {
-    axios.get('/wp-json/reactdb/v1/csv/read')
-      .then(res => setCsvData(res.data))
-      .catch(err => console.error(err));
-  }, []);
-
   return (
-    <div>
-      <h1>CSV Data</h1>
-      <pre>{JSON.stringify(csvData, null, 2)}</pre>
-    </div>
+    <Router>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Navigate to="/import" />} />
+          <Route path="/import" element={<CSVImport />} />
+          <Route path="/export" element={<CSVExport />} />
+          <Route path="/db" element={<DatabaseManager />} />
+          <Route path="/logs" element={<Logs />} />
+        </Routes>
+      </Layout>
+    </Router>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const title = screen.getByText(/React DB Manager/i);
+  expect(title).toBeInTheDocument();
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+const Header = () => (
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        React DB Manager
+      </Typography>
+      <Typography variant="body1" sx={{ mr: 2 }}>Admin</Typography>
+      <Button color="inherit">Logout</Button>
+    </Toolbar>
+  </AppBar>
+);
+
+export default Header;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Header from './Header';
+import Sidebar from './Sidebar';
+
+const Layout = ({ children }) => (
+  <Box sx={{ display: 'flex' }}>
+    <Header />
+    <Sidebar />
+    <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Toolbar />
+      {children}
+    </Box>
+  </Box>
+);
+
+export default Layout;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Toolbar from '@mui/material/Toolbar';
+
+const navItems = [
+  { text: 'CSVインポート', to: '/import' },
+  { text: 'CSVエクスポート', to: '/export' },
+  { text: 'データベース一覧', to: '/db' },
+  { text: '操作ログ', to: '/logs' }
+];
+
+const drawerWidth = 240;
+
+const Sidebar = () => (
+  <Drawer
+    variant="permanent"
+    sx={{
+      width: drawerWidth,
+      flexShrink: 0,
+      [`& .MuiDrawer-paper`]: {
+        width: drawerWidth,
+        boxSizing: 'border-box'
+      }
+    }}
+  >
+    <Toolbar />
+    <List>
+      {navItems.map((item) => (
+        <ListItem key={item.to} disablePadding>
+          <ListItemButton component={NavLink} to={item.to}>
+            <ListItemText primary={item.text} />
+          </ListItemButton>
+        </ListItem>
+      ))}
+    </List>
+  </Drawer>
+);
+
+export default Sidebar;

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,12 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import CssBaseline from '@mui/material/CssBaseline';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
+    <CssBaseline />
     <App />
   </React.StrictMode>
 );

--- a/src/pages/CSVExport.js
+++ b/src/pages/CSVExport.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Link from '@mui/material/Link';
+
+const CSVExport = () => {
+  const [downloadUrl, setDownloadUrl] = useState('');
+
+  const handleExport = () => {
+    // placeholder for export logic
+    setDownloadUrl('/path/to/export.csv');
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        CSVエクスポート
+      </Typography>
+      <TextField select label="テーブルを選択" fullWidth sx={{ mb: 2 }}>
+        <MenuItem value="">テーブルを選択</MenuItem>
+      </TextField>
+      <Button variant="contained" onClick={handleExport}>
+        エクスポート
+      </Button>
+      {downloadUrl && (
+        <Box sx={{ mt: 2 }}>
+          <Link href={downloadUrl} download>
+            ダウンロード
+          </Link>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default CSVExport;

--- a/src/pages/CSVImport.js
+++ b/src/pages/CSVImport.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+
+const CSVImport = () => {
+  const [log, setLog] = useState('');
+
+  const handleUpload = () => {
+    // placeholder for upload logic
+    setLog('アップロードしました');
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        CSVインポート
+      </Typography>
+      <Paper variant="outlined" sx={{ p: 4, textAlign: 'center', mb: 2 }}>
+        <input type="file" accept=".csv" />
+      </Paper>
+      <Button variant="contained" onClick={handleUpload}>
+        アップロード
+      </Button>
+      {log && (
+        <Typography sx={{ mt: 2 }}>
+          {log}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default CSVImport;

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+
+const DatabaseManager = () => (
+  <Box sx={{ display: 'flex' }}>
+    <Box sx={{ width: 240, pr: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        テーブル一覧
+      </Typography>
+      <List dense>
+        <ListItem>sample_table</ListItem>
+      </List>
+    </Box>
+    <Box sx={{ flexGrow: 1 }}>
+      <Typography variant="h6" gutterBottom>
+        テーブル内容
+      </Typography>
+      <Paper variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>id</TableCell>
+              <TableCell>name</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>-</TableCell>
+              <TableCell>-</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  </Box>
+);
+
+export default DatabaseManager;

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+
+const Logs = () => (
+  <Box>
+    <Typography variant="h5" gutterBottom>
+      操作ログ
+    </Typography>
+    <Paper variant="outlined">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>日時</TableCell>
+            <TableCell>ユーザー</TableCell>
+            <TableCell>操作内容</TableCell>
+            <TableCell>詳細</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>-</TableCell>
+            <TableCell>-</TableCell>
+            <TableCell>-</TableCell>
+            <TableCell>-</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Paper>
+  </Box>
+);
+
+export default Logs;


### PR DESCRIPTION
## Summary
- switch layout components to Material UI
- style pages (CSV Import/Export, DB manager, logs) using Material UI widgets
- add Material UI dependencies
- insert CssBaseline in index

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f88f60e808323b3f46f1d1b29502f