### PR TITLE
Enable demo data fallback for standalone mode

### DIFF
--- a/react-db-plugin/includes/api.php
+++ b/react-db-plugin/includes/api.php
@@ -22,4 +22,16 @@ add_action('rest_api_init', function () {
             return current_user_can('manage_options');
         }
     ]);
+
+    register_rest_route('reactdb/v1', '/logs', [
+        'methods' => 'GET',
+        'callback' => function () {
+            global $wpdb;
+            $table = $wpdb->prefix . 'reactdb_logs';
+            return $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 10", ARRAY_A);
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
 });

--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -1,0 +1,19 @@
+<?php
+function reactdb_shortcode($atts) {
+    global $wpdb;
+    $atts = shortcode_atts([
+        'db' => '',
+        'data' => ''
+    ], $atts);
+
+    $table = $atts['db'] ? $wpdb->prefix . $atts['db'] : '';
+    $result = [];
+    if ($table) {
+        $result = $wpdb->get_row("SELECT * FROM {$table} LIMIT 1", ARRAY_A);
+    }
+    if ($result) {
+        return '<pre>' . esc_html(print_r($result, true)) . '</pre>';
+    }
+    return '<div>No data</div>';
+}
+add_shortcode('reactdb', 'reactdb_shortcode');

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -16,8 +16,22 @@ add_action('admin_menu', function() {
         'react-db-plugin',
         function() {
             echo '<div id="react-db-root"></div>';
-            wp_enqueue_script('react-db-plugin-script', plugins_url('/assets/app.js', __FILE__), [], '1.0', true);
-            wp_enqueue_style('react-db-plugin-style', plugins_url('/assets/app.css', __FILE__), [], '1.0');
+            wp_enqueue_script(
+                'react-db-plugin-script',
+                plugins_url('/assets/app.js', __FILE__),
+                [],
+                '1.0',
+                true
+            );
+            wp_enqueue_style(
+                'react-db-plugin-style',
+                plugins_url('/assets/app.css', __FILE__),
+                [],
+                '1.0'
+            );
+            wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
+                'isPlugin' => true
+            ]);
         }
     );
 });
@@ -26,6 +40,7 @@ add_action('admin_menu', function() {
 require_once __DIR__ . '/includes/api.php';
 require_once __DIR__ . '/includes/csv-handler.php';
 require_once __DIR__ . '/includes/log-handler.php';
+require_once __DIR__ . '/includes/shortcode.php';
 
 register_activation_hook(__FILE__, function() {
     global $wpdb;

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ function App() {
     <Router>
       <Layout>
         <Routes>
-          <Route path="/" element={<Navigate to="/import" />} />
+          <Route path="/" element={<Navigate to="/db" />} />
           <Route path="/import" element={<CSVImport />} />
           <Route path="/export" element={<CSVExport />} />
           <Route path="/db" element={<DatabaseManager />} />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 
 const Header = () => (
-  <AppBar position="static">
+  <AppBar position="fixed" color="primary">
     <Toolbar>
       <Typography variant="h6" sx={{ flexGrow: 1 }}>
         React DB Manager

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -5,12 +5,14 @@ import Header from './Header';
 import Sidebar from './Sidebar';
 
 const Layout = ({ children }) => (
-  <Box sx={{ display: 'flex' }}>
+  <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
     <Header />
-    <Sidebar />
-    <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-      <Toolbar />
-      {children}
+    <Box sx={{ display: 'flex', flexGrow: 1 }}>
+      <Sidebar />
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Toolbar />
+        {children}
+      </Box>
     </Box>
   </Box>
 );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -24,7 +24,10 @@ const Sidebar = () => (
       flexShrink: 0,
       [`& .MuiDrawer-paper`]: {
         width: drawerWidth,
-        boxSizing: 'border-box'
+        boxSizing: 'border-box',
+        backgroundColor: '#fff',
+        top: 64,
+        height: 'calc(100% - 64px)'
       }
     }}
   >

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background-color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/src/isPlugin.js
+++ b/src/isPlugin.js
@@ -1,0 +1,2 @@
+const isPlugin = Boolean(window.ReactDbGlobals && window.ReactDbGlobals.isPlugin);
+export default isPlugin;

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
@@ -9,39 +9,67 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import isPlugin from '../isPlugin';
 
-const DatabaseManager = () => (
-  <Box sx={{ display: 'flex' }}>
-    <Box sx={{ width: 240, pr: 2 }}>
-      <Typography variant="h6" gutterBottom>
-        テーブル一覧
-      </Typography>
-      <List dense>
-        <ListItem>sample_table</ListItem>
-      </List>
+const DatabaseManager = () => {
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    if (isPlugin) {
+      fetch('/wp-json/reactdb/v1/csv/read')
+        .then((r) => r.json())
+        .then((data) => setRows(data))
+        .catch(() => {
+          setRows([
+            ['id', 'name'],
+            ['1', 'データ取得失敗']
+          ]);
+        });
+    } else {
+      setRows([
+        ['id', 'name'],
+        ['1', 'デモデータ']
+      ]);
+    }
+  }, []);
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Box sx={{ width: 240, pr: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          テーブル一覧
+        </Typography>
+        <List dense>
+          <ListItem>{isPlugin ? 'wp_table' : 'sample_table'}</ListItem>
+        </List>
+      </Box>
+      <Box sx={{ flexGrow: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          テーブル内容
+        </Typography>
+        <Paper variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                {rows[0]?.map((h, i) => (
+                  <TableCell key={i}>{h}</TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.slice(1).map((row, i) => (
+                <TableRow key={i}>
+                  {row.map((cell, j) => (
+                    <TableCell key={j}>{cell}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      </Box>
     </Box>
-    <Box sx={{ flexGrow: 1 }}>
-      <Typography variant="h6" gutterBottom>
-        テーブル内容
-      </Typography>
-      <Paper variant="outlined">
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>id</TableCell>
-              <TableCell>name</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            <TableRow>
-              <TableCell>-</TableCell>
-              <TableCell>-</TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </Paper>
-    </Box>
-  </Box>
-);
+  );
+};
 
 export default DatabaseManager;

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
@@ -7,33 +7,57 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import isPlugin from '../isPlugin';
 
-const Logs = () => (
-  <Box>
-    <Typography variant="h5" gutterBottom>
-      操作ログ
-    </Typography>
-    <Paper variant="outlined">
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>日時</TableCell>
-            <TableCell>ユーザー</TableCell>
-            <TableCell>操作内容</TableCell>
-            <TableCell>詳細</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>-</TableCell>
-            <TableCell>-</TableCell>
-            <TableCell>-</TableCell>
-            <TableCell>-</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </Paper>
-  </Box>
-);
+const Logs = () => {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    if (isPlugin) {
+      fetch('/wp-json/reactdb/v1/logs')
+        .then((r) => r.json())
+        .then((data) => setLogs(data))
+        .catch(() => {
+          setLogs([
+            { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
+          ]);
+        });
+    } else {
+      setLogs([
+        { created_at: '2024-01-01', user_id: 'demo', action: 'view', description: 'デモログ' }
+      ]);
+    }
+  }, []);
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        操作ログ
+      </Typography>
+      <Paper variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>日時</TableCell>
+              <TableCell>ユーザー</TableCell>
+              <TableCell>操作内容</TableCell>
+              <TableCell>詳細</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {logs.map((log, i) => (
+              <TableRow key={i}>
+                <TableCell>{log.created_at}</TableCell>
+                <TableCell>{log.user_id}</TableCell>
+                <TableCell>{log.action}</TableCell>
+                <TableCell>{log.description}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  );
+};
 
 export default Logs;


### PR DESCRIPTION
## Summary
- pass plugin flag to React via `wp_localize_script`
- expose logs via new REST endpoint
- provide `[reactdb]` shortcode example
- lighten UI colors for readability
- show real data when running in WP and demo data otherwise
- restore header background to blue

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e5a67cc8323ad33e902435288ff