### PR TITLE
Add shortcode input parser and Gutenberg block

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ WordPress admin panel.
 Once activated, a new "React DB" menu will appear and open the React
 interface.
 
+## Shortcode and Block
+
+Use the `[reactdb]` shortcode or **React DB Block** to display a row from a
+database table. Both accept an `input` attribute formatted as
+`DB:"table",data` to specify the table and optional extra data. Example:
+
+```wordpress
+[reactdb input='DB:"c1",sample']
+```
+
 ## Development Notes
 
 - React source files live under `src/`.

--- a/react-db-plugin/assets/block.css
+++ b/react-db-plugin/assets/block.css
@@ -1,0 +1,6 @@
+.reactdb-block {
+    border: 1px solid #ccc;
+    padding: 1em;
+    margin: 1em 0;
+    background: #f9f9f9;
+}

--- a/react-db-plugin/assets/block.js
+++ b/react-db-plugin/assets/block.js
@@ -1,0 +1,25 @@
+(function(blocks, element, components){
+    var el = element.createElement;
+    var TextControl = components.TextControl;
+
+    blocks.registerBlockType('reactdb/block', {
+        title: 'React DB Block',
+        icon: 'database',
+        category: 'widgets',
+        attributes: {
+            input: { type: 'string', default: '' }
+        },
+        edit: function(props){
+            return el('div', { className: props.className },
+                el(TextControl, {
+                    label: 'Input',
+                    value: props.attributes.input,
+                    onChange: function(val){ props.setAttributes({input: val}); }
+                })
+            );
+        },
+        save: function(){
+            return null; // server-side
+        }
+    });
+})(window.wp.blocks, window.wp.element, window.wp.components);

--- a/react-db-plugin/includes/block.php
+++ b/react-db-plugin/includes/block.php
@@ -1,0 +1,35 @@
+<?php
+function reactdb_register_block() {
+    wp_register_script(
+        'reactdb-block',
+        plugins_url('assets/block.js', dirname(__DIR__) . '/react-db-plugin.php'),
+        ['wp-blocks', 'wp-element', 'wp-components'],
+        '1.0',
+        true
+    );
+
+    wp_register_style(
+        'reactdb-block-style',
+        plugins_url('assets/block.css', dirname(__DIR__) . '/react-db-plugin.php'),
+        [],
+        '1.0'
+    );
+
+    register_block_type('reactdb/block', [
+        'editor_script'   => 'reactdb-block',
+        'editor_style'    => 'reactdb-block-style',
+        'style'           => 'reactdb-block-style',
+        'render_callback' => 'reactdb_block_render',
+        'attributes'      => [
+            'input' => [
+                'type'    => 'string',
+                'default' => ''
+            ]
+        ]
+    ]);
+}
+add_action('init', 'reactdb_register_block');
+
+function reactdb_block_render($atts) {
+    return reactdb_shortcode($atts);
+}

--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -1,19 +1,32 @@
 <?php
 function reactdb_shortcode($atts) {
     global $wpdb;
+
     $atts = shortcode_atts([
-        'db' => '',
-        'data' => ''
+        'db'    => '',
+        'data'  => '',
+        'input' => ''
     ], $atts);
 
-    $table = $atts['db'] ? $wpdb->prefix . $atts['db'] : '';
+    // Parse `input` attribute formatted as DB:"table",data
+    if (!empty($atts['input']) && preg_match('/DB:"([^"]+)"\s*,\s*(.+)/', $atts['input'], $m)) {
+        $atts['db']   = $m[1];
+        $atts['data'] = $m[2];
+    }
+
+    $table  = $atts['db'] ? $wpdb->prefix . $atts['db'] : '';
     $result = [];
+
     if ($table) {
         $result = $wpdb->get_row("SELECT * FROM {$table} LIMIT 1", ARRAY_A);
     }
+
     if ($result) {
-        return '<pre>' . esc_html(print_r($result, true)) . '</pre>';
+        $content  = '<pre>' . esc_html(print_r($result, true)) . '</pre>';
+    } else {
+        $content  = '<div>No data</div>';
     }
-    return '<div>No data</div>';
+
+    return '<div class="reactdb-block">' . $content . '</div>';
 }
 add_shortcode('reactdb', 'reactdb_shortcode');

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -41,6 +41,7 @@ require_once __DIR__ . '/includes/api.php';
 require_once __DIR__ . '/includes/csv-handler.php';
 require_once __DIR__ . '/includes/log-handler.php';
 require_once __DIR__ . '/includes/shortcode.php';
+require_once __DIR__ . '/includes/block.php';
 
 register_activation_hook(__FILE__, function() {
     global $wpdb;


### PR DESCRIPTION
## Summary
- allow `reactdb` shortcode to parse `input` like `DB:"c1",data`
- wrap shortcode output with `.reactdb-block` styling
- register new dynamic Gutenberg block that uses the shortcode
- add assets for the block
- document shortcode and block usage

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa48ef6a88323ab7bbf4bf43d7a6c