### PR TITLE
Add postbuild script for WordPress plugin assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ npm install
 npm run build
 ```
 
-Copy the contents of the generated `build` directory into
-`react-db-plugin/assets`. The plugin expects `app.js` and `app.css` to be
-located there.
+After building, the script defined in `package.json` copies the generated
+files into `react-db-plugin/assets` as `app.js` and `app.css`.
 
 3. Move the `react-db-plugin` directory to your WordPress
 `wp-content/plugins` directory and activate **React DB Plugin** from the

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "node scripts/copy-build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/scripts/copy-build.js
+++ b/scripts/copy-build.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const buildDir = path.join(__dirname, '..', 'build');
+const targetDir = path.join(__dirname, '..', 'react-db-plugin', 'assets');
+
+function findFile(dir, pattern) {
+  const files = fs.readdirSync(dir);
+  const match = files.find(f => pattern.test(f));
+  return match ? path.join(dir, match) : null;
+}
+
+function copyFile(srcPattern, destName) {
+  const src = findFile(srcPattern.dir, srcPattern.regex);
+  if (!src) {
+    throw new Error(`File matching ${srcPattern.regex} not found in ${srcPattern.dir}`);
+  }
+  const dest = path.join(targetDir, destName);
+  fs.copyFileSync(src, dest);
+  console.log(`Copied ${src} -> ${dest}`);
+}
+
+try {
+  copyFile({dir: path.join(buildDir, 'static', 'js'), regex: /^main.*\.js$/}, 'app.js');
+  copyFile({dir: path.join(buildDir, 'static', 'css'), regex: /^main.*\.css$/}, 'app.css');
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add Node script `scripts/copy-build.js` to rename main build files to `app.js` and `app.css`
- run the script automatically after `npm run build`
- document the automatic copy step in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa64a3e6083238df1b787268691ee