### PR TITLE
Expose frontend page via shortcode

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -30,3 +30,33 @@ function reactdb_shortcode($atts) {
     return '<div class="reactdb-block">' . $content . '</div>';
 }
 add_shortcode('reactdb', 'reactdb_shortcode');
+
+function reactdb_app_shortcode() {
+    if (!is_user_logged_in()) {
+        return '<p>Please log in to view this page.</p>';
+    }
+
+    // Render container for the React app on the front-end
+    ob_start();
+    echo '<div id="root"></div>';
+
+    wp_enqueue_script(
+        'react-db-plugin-script',
+        plugins_url('assets/app.js', dirname(__DIR__) . '/react-db-plugin.php'),
+        [],
+        '1.0',
+        true
+    );
+    wp_enqueue_style(
+        'react-db-plugin-style',
+        plugins_url('assets/app.css', dirname(__DIR__) . '/react-db-plugin.php'),
+        [],
+        '1.0'
+    );
+    wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
+        'isPlugin' => false
+    ]);
+
+    return ob_get_clean();
+}
+add_shortcode('reactdb_app', 'reactdb_app_shortcode');

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -15,17 +15,19 @@ add_action('admin_menu', function() {
         'manage_options',
         'react-db-plugin',
         function() {
-            echo '<div id="react-db-root"></div>';
+            // The React app expects a container with id "root"
+            // so mirror that here when rendering inside the admin page
+            echo '<div id="root"></div>';
             wp_enqueue_script(
                 'react-db-plugin-script',
-                plugins_url('/assets/app.js', __FILE__),
+                plugins_url('assets/app.js', __FILE__),
                 [],
                 '1.0',
                 true
             );
             wp_enqueue_style(
                 'react-db-plugin-style',
-                plugins_url('/assets/app.css', __FILE__),
+                plugins_url('assets/app.css', __FILE__),
                 [],
                 '1.0'
             );
@@ -59,4 +61,16 @@ register_activation_hook(__FILE__, function() {
 
     require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
     dbDelta($sql);
+
+    // Create front-end page for the React app if it doesn't exist
+    if (!get_page_by_path('react-db-app')) {
+        wp_insert_post([
+            'post_title'   => 'React DB App',
+            'post_name'    => 'react-db-app',
+            'post_status'  => 'publish',
+            'post_type'    => 'page',
+            'post_content' => '[reactdb_app]'
+        ]);
+        flush_rewrite_rules();
+    }
 });


### PR DESCRIPTION
## Summary
- add `[reactdb_app]` shortcode that loads the React app for logged-in users
- create a public page on activation that embeds this shortcode

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faf80af5083238adcdbd29f72c495