### PR TITLE
Fix demo mode and hide theme chrome

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -53,8 +53,11 @@ function reactdb_app_shortcode() {
         [],
         '1.0'
     );
+    $user = wp_get_current_user();
     wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
-        'isPlugin' => false
+        'isPlugin'    => true,
+        'currentUser' => $user->display_name,
+        'logoutUrl'   => wp_logout_url()
     ]);
 
     return ob_get_clean();

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -31,8 +31,11 @@ add_action('admin_menu', function() {
                 [],
                 '1.0'
             );
+            $user = wp_get_current_user();
             wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
-                'isPlugin' => true
+                'isPlugin'    => true,
+                'currentUser' => $user->display_name,
+                'logoutUrl'   => wp_logout_url()
             ]);
         }
     );
@@ -73,4 +76,15 @@ register_activation_hook(__FILE__, function() {
         ]);
         flush_rewrite_rules();
     }
+});
+
+// Use blank template for the React DB page
+add_filter('template_include', function ($template) {
+    if (is_page('react-db-app')) {
+        $custom = plugin_dir_path(__FILE__) . 'templates/blank.php';
+        if (file_exists($custom)) {
+            return $custom;
+        }
+    }
+    return $template;
 });

--- a/react-db-plugin/templates/blank.php
+++ b/react-db-plugin/templates/blank.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Template Name: React DB Blank
+ */
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo('charset'); ?>" />
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php
+while ( have_posts() ) :
+    the_post();
+    the_content();
+endwhile;
+wp_footer();
+?>
+</body>
+</html>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,7 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import { currentUser, logoutUrl } from '../isPlugin';
 
 const Header = () => (
   <AppBar position="fixed" color="default" sx={{ backgroundColor: '#fff' }}>
@@ -10,8 +11,8 @@ const Header = () => (
       <Typography variant="h6" sx={{ flexGrow: 1 }}>
         React DB Manager
       </Typography>
-      <Typography variant="body1" sx={{ mr: 2 }}>Admin</Typography>
-      <Button color="inherit">Logout</Button>
+      <Typography variant="body1" sx={{ mr: 2 }}>{currentUser || 'User'}</Typography>
+      <Button color="inherit" href={logoutUrl}>Logout</Button>
     </Toolbar>
   </AppBar>
 );

--- a/src/isPlugin.js
+++ b/src/isPlugin.js
@@ -1,2 +1,5 @@
-const isPlugin = Boolean(window.ReactDbGlobals && window.ReactDbGlobals.isPlugin);
+const globals = window.ReactDbGlobals || {};
+export const currentUser = globals.currentUser || '';
+export const logoutUrl = globals.logoutUrl || '';
+const isPlugin = Boolean(globals.isPlugin);
 export default isPlugin;


### PR DESCRIPTION
## Summary
- enable full plugin mode from shortcode
- show logged-in user in the React header
- localize logout URL
- add blank page template to remove theme header/footer

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe59e344832387b093154f6697a7