### PR TITLE
Fix root redirect with inline script

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -47,6 +47,11 @@ function reactdb_app_shortcode() {
         '1.0',
         true
     );
+    wp_add_inline_script(
+        'react-db-plugin-script',
+        "if (location.hash === '#/db') { location.hash = '#/'; }",
+        'after'
+    );
     wp_enqueue_style(
         'react-db-plugin-style',
         plugins_url('assets/app.css', dirname(__DIR__) . '/react-db-plugin.php'),

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -25,6 +25,11 @@ add_action('admin_menu', function() {
                 '1.0',
                 true
             );
+            wp_add_inline_script(
+                'react-db-plugin-script',
+                "if (location.hash === '#/db') { location.hash = '#/'; }",
+                'after'
+            );
             wp_enqueue_style(
                 'react-db-plugin-style',
                 plugins_url('assets/app.css', __FILE__),

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import CSVImport from './pages/CSVImport';
 import CSVExport from './pages/CSVExport';
@@ -11,7 +11,7 @@ function App() {
     <Router>
       <Layout>
         <Routes>
-          <Route path="/" element={<Navigate to="/db" />} />
+          <Route path="/" element={<DatabaseManager />} />
           <Route path="/import" element={<CSVImport />} />
           <Route path="/export" element={<CSVExport />} />
           <Route path="/db" element={<DatabaseManager />} />


### PR DESCRIPTION
## Summary
- inject inline script in plugin pages to reset `#/db` hash to `#/`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff5a06e4083238c2f0a2eae3ac643