### PR TITLE
Fix hash redirect

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -47,11 +47,6 @@ function reactdb_app_shortcode() {
         '1.0',
         true
     );
-    wp_add_inline_script(
-        'react-db-plugin-script',
-        "if (location.hash === '#/db') { location.hash = '#/'; }",
-        'after'
-    );
     wp_enqueue_style(
         'react-db-plugin-style',
         plugins_url('assets/app.css', dirname(__DIR__) . '/react-db-plugin.php'),


### PR DESCRIPTION
## Summary
- remove inline script that forced `/db` hash redirect

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684015ea118483239a253c4e50f4eee9