### PR TITLE
Fix hash redirect

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -47,11 +47,6 @@ function reactdb_app_shortcode() {
         '1.0',
         true
     );
-    wp_add_inline_script(
-        'react-db-plugin-script',
-        "if (location.hash === '#/db') { location.hash = '#/'; }",
-        'after'
-    );
     wp_enqueue_style(
         'react-db-plugin-style',
         plugins_url('assets/app.css', dirname(__DIR__) . '/react-db-plugin.php'),
@@ -64,6 +59,11 @@ function reactdb_app_shortcode() {
         'currentUser' => $user->display_name,
         'logoutUrl'   => wp_logout_url()
     ]);
+    wp_add_inline_script(
+        'react-db-plugin-script',
+        "function reactdb_fix(){if(location.hash==='#/db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);reactdb_fix();",
+        'after'
+    );
 
     return ob_get_clean();
 }

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -35,6 +35,11 @@ add_action('admin_menu', function() {
                 'currentUser' => $user->display_name,
                 'logoutUrl'   => wp_logout_url()
             ]);
+            wp_add_inline_script(
+                'react-db-plugin-script',
+                "function reactdb_fix(){if(location.hash==='#/db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);reactdb_fix();",
+                'after'
+            );
         }
     );
 });


### PR DESCRIPTION
## Summary
- prevent automatic `#/db` redirect using hashchange listener

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684015ea118483239a253c4e50f4eee9