### PR TITLE
Improve hash redirect script

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -61,7 +61,7 @@ function reactdb_app_shortcode() {
     ]);
     wp_add_inline_script(
         'react-db-plugin-script',
-        "function reactdb_fix(){if(location.hash==='#/db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);reactdb_fix();",
+        "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
         'after'
     );
 

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -37,7 +37,7 @@ add_action('admin_menu', function() {
             ]);
             wp_add_inline_script(
                 'react-db-plugin-script',
-                "function reactdb_fix(){if(location.hash==='#/db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);reactdb_fix();",
+                "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
                 'after'
             );
         }


### PR DESCRIPTION
## Summary
- fix inline script to normalize `#/db` hash properly for plugin and shortcode

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684054e8b6c88323b83f806e60707e8a