### PR TITLE
Fix logs and db redirect

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -61,7 +61,16 @@ function reactdb_app_shortcode() {
     ]);
     wp_add_inline_script(
         'react-db-plugin-script',
-        "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
+        "function reactdb_fix(){\n" +
+        "  var h=location.hash.replace(/^#/, '');\n" +
+        "  if(/^\\/?db(\\/|$)/.test(h)){location.hash='#/';return;}\n" +
+        "  if(/\\/db(\\/)?$/.test(location.pathname)){\n" +
+        "    var base=location.pathname.replace(/\\/db(\\/)?$/, '/');\n" +
+        "    location.replace(base + location.search + '#/');\n" +
+        "  }\n" +
+        "}\n" +
+        "window.addEventListener('hashchange',reactdb_fix);\n" +
+        "document.addEventListener('DOMContentLoaded',reactdb_fix);",
         'after'
     );
 

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -37,7 +37,16 @@ add_action('admin_menu', function() {
             ]);
             wp_add_inline_script(
                 'react-db-plugin-script',
-                "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
+                "function reactdb_fix(){\n" +
+                "  var h=location.hash.replace(/^#/, '');\n" +
+                "  if(/^\\/?db(\\/|$)/.test(h)){location.hash='#/';return;}\n" +
+                "  if(/\\/db(\\/)?$/.test(location.pathname)){\n" +
+                "    var base=location.pathname.replace(/\\/db(\\/)?$/, '/');\n" +
+                "    location.replace(base + location.search + '#/');\n" +
+                "  }\n" +
+                "}\n" +
+                "window.addEventListener('hashchange',reactdb_fix);\n" +
+                "document.addEventListener('DOMContentLoaded',reactdb_fix);",
                 'after'
             );
         }

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -16,7 +16,15 @@ const Logs = () => {
     if (isPlugin) {
       fetch('/wp-json/reactdb/v1/logs')
         .then((r) => r.json())
-        .then((data) => setLogs(data))
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setLogs(data);
+          } else {
+            setLogs([
+              { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
+            ]);
+          }
+        })
         .catch(() => {
           setLogs([
             { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
@@ -45,14 +53,22 @@ const Logs = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {logs.map((log, i) => (
-              <TableRow key={i}>
-                <TableCell>{log.created_at}</TableCell>
-                <TableCell>{log.user_id}</TableCell>
-                <TableCell>{log.action}</TableCell>
-                <TableCell>{log.description}</TableCell>
+            {logs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center">
+                  ログがありません
+                </TableCell>
               </TableRow>
-            ))}
+            ) : (
+              logs.map((log, i) => (
+                <TableRow key={i}>
+                  <TableCell>{log.created_at}</TableCell>
+                  <TableCell>{log.user_id}</TableCell>
+                  <TableCell>{log.action}</TableCell>
+                  <TableCell>{log.description}</TableCell>
+                </TableRow>
+              ))
+            )}
           </TableBody>
         </Table>
       </Paper>


### PR DESCRIPTION
## Summary
- handle API errors gracefully on the Logs page
- show message when no logs are found
- improve hash redirect script to catch `/db` variations
- restore /db redirect prevention via improved inline script

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c37a51a883239288ebf154cc09bd