### PR TITLE
Improve db redirect script and logs page

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -61,7 +61,11 @@ function reactdb_app_shortcode() {
     ]);
     wp_add_inline_script(
         'react-db-plugin-script',
-        "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
+        "function reactdb_fix(){" .
+        "var h=location.hash.replace(/^#/, '');" .
+        "if(/^\\/?db\\/?$/.test(h)){location.hash='#/';}" .
+        "if(/\\/db\\/?$/.test(location.pathname)){location.pathname=location.pathname.replace(/\\/db\\/?$/, '/');}}" .
+        "window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
         'after'
     );
 

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -37,7 +37,11 @@ add_action('admin_menu', function() {
             ]);
             wp_add_inline_script(
                 'react-db-plugin-script',
-                "function reactdb_fix(){var h=location.hash.replace(/^#/, '');if(h==='/db'||h==='db'){location.hash='#/';}}window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
+                "function reactdb_fix(){" .
+                "var h=location.hash.replace(/^#/, '');" .
+                "if(/^\\/?db\\/?$/.test(h)){location.hash='#/';}" .
+                "if(/\\/db\\/?$/.test(location.pathname)){location.pathname=location.pathname.replace(/\\/db\\/?$/, '/');}}" .
+                "window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
                 'after'
             );
         }

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -11,23 +11,42 @@ import isPlugin from '../isPlugin';
 
 const Logs = () => {
   const [logs, setLogs] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (isPlugin) {
       fetch('/wp-json/reactdb/v1/logs')
         .then((r) => r.json())
-        .then((data) => setLogs(data))
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setLogs(data);
+          } else {
+            setLogs([
+              { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
+            ]);
+          }
+        })
         .catch(() => {
           setLogs([
             { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
           ]);
-        });
+        })
+        .finally(() => setLoading(false));
     } else {
       setLogs([
         { created_at: '2024-01-01', user_id: 'demo', action: 'view', description: 'デモログ' }
       ]);
+      setLoading(false);
     }
   }, []);
+
+  if (loading) {
+    return (
+      <Box>
+        <Typography variant="h6">読み込み中...</Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box>
@@ -45,14 +64,22 @@ const Logs = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {logs.map((log, i) => (
-              <TableRow key={i}>
-                <TableCell>{log.created_at}</TableCell>
-                <TableCell>{log.user_id}</TableCell>
-                <TableCell>{log.action}</TableCell>
-                <TableCell>{log.description}</TableCell>
+            {logs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} align="center">
+                  ログがありません
+                </TableCell>
               </TableRow>
-            ))}
+            ) : (
+              logs.map((log, i) => (
+                <TableRow key={i}>
+                  <TableCell>{log.created_at}</TableCell>
+                  <TableCell>{log.user_id}</TableCell>
+                  <TableCell>{log.action}</TableCell>
+                  <TableCell>{log.description}</TableCell>
+                </TableRow>
+              ))
+            )}
           </TableBody>
         </Table>
       </Paper>


### PR DESCRIPTION
## Summary
- refine inline redirect to catch `/db` paths with or without trailing slash
- maintain logs display when API gives invalid results

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c37a51a883239288ebf154cc09bd