### PR TITLE
Fix DB redirect handling

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -65,6 +65,7 @@ function reactdb_app_shortcode() {
         "var h=location.hash.replace(/^#/, '');" .
         "if(/^\\/?db\\/?$/.test(h)){location.hash='#/';}" .
         "if(/\\/db\\/?$/.test(location.pathname)){location.pathname=location.pathname.replace(/\\/db\\/?$/, '/');}}" .
+        "reactdb_fix();" .
         "window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
         'after'
     );

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -41,6 +41,7 @@ add_action('admin_menu', function() {
                 "var h=location.hash.replace(/^#/, '');" .
                 "if(/^\\/?db\\/?$/.test(h)){location.hash='#/';}" .
                 "if(/\\/db\\/?$/.test(location.pathname)){location.pathname=location.pathname.replace(/\\/db\\/?$/, '/');}}" .
+                "reactdb_fix();" .
                 "window.addEventListener('hashchange',reactdb_fix);document.addEventListener('DOMContentLoaded',reactdb_fix);",
                 'after'
             );


### PR DESCRIPTION
## Summary
- ensure the inline script executes at load time so unwanted `#/db` redirects back to `#/`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ebbc5d6883239f8e83cf8ac4938d