### PR TITLE
Handle failed REST API responses

### DIFF
--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -17,8 +17,19 @@ const DatabaseManager = () => {
   useEffect(() => {
     if (isPlugin) {
       fetch('/wp-json/reactdb/v1/csv/read')
-        .then((r) => r.json())
-        .then((data) => setRows(data))
+        .then((r) => {
+          if (!r.ok) {
+            throw new Error('fetch failed');
+          }
+          return r.json();
+        })
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setRows(data);
+          } else {
+            throw new Error('invalid data');
+          }
+        })
         .catch(() => {
           setRows([
             ['id', 'name'],

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -16,7 +16,12 @@ const Logs = () => {
   useEffect(() => {
     if (isPlugin) {
       fetch('/wp-json/reactdb/v1/logs')
-        .then((r) => r.json())
+        .then((r) => {
+          if (!r.ok) {
+            throw new Error('fetch failed');
+          }
+          return r.json();
+        })
         .then((data) => {
           if (Array.isArray(data)) {
             setLogs(data);


### PR DESCRIPTION
## Summary
- handle fetch errors in `DatabaseManager` and `Logs` pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841344e66208323a3c4b6d3634d8da0