### PR TITLE
Handle unauthorized REST API errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# plugin build output
+react-db-plugin/assets/*
+!react-db-plugin/assets/.gitkeep

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -19,6 +19,9 @@ const DatabaseManager = () => {
       fetch('/wp-json/reactdb/v1/csv/read')
         .then((r) => {
           if (!r.ok) {
+            if (r.status === 401) {
+              throw new Error('unauthorized');
+            }
             throw new Error('fetch failed');
           }
           return r.json();
@@ -30,11 +33,18 @@ const DatabaseManager = () => {
             throw new Error('invalid data');
           }
         })
-        .catch(() => {
-          setRows([
-            ['id', 'name'],
-            ['1', 'データ取得失敗']
-          ]);
+        .catch((err) => {
+          if (err.message === 'unauthorized') {
+            setRows([
+              ['Error'],
+              ['権限がありません']
+            ]);
+          } else {
+            setRows([
+              ['id', 'name'],
+              ['1', 'データ取得失敗']
+            ]);
+          }
         });
     } else {
       setRows([

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -18,6 +18,9 @@ const Logs = () => {
       fetch('/wp-json/reactdb/v1/logs')
         .then((r) => {
           if (!r.ok) {
+            if (r.status === 401) {
+              throw new Error('unauthorized');
+            }
             throw new Error('fetch failed');
           }
           return r.json();
@@ -31,10 +34,16 @@ const Logs = () => {
             ]);
           }
         })
-        .catch(() => {
-          setLogs([
-            { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
-          ]);
+        .catch((err) => {
+          if (err.message === 'unauthorized') {
+            setLogs([
+              { created_at: '-', user_id: '-', action: '-', description: '権限がありません' }
+            ]);
+          } else {
+            setLogs([
+              { created_at: '-', user_id: '-', action: '-', description: '取得失敗' }
+            ]);
+          }
         })
         .finally(() => setLoading(false));
     } else {


### PR DESCRIPTION
## Summary
- display friendly messages when API calls fail due to missing permission

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684135e5452c8323963ac773c4311e8f