### PR TITLE
Implement REST API nonce

### DIFF
--- a/react-db-plugin/includes/shortcode.php
+++ b/react-db-plugin/includes/shortcode.php
@@ -58,7 +58,8 @@ function reactdb_app_shortcode() {
     wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
         'isPlugin'    => true,
         'currentUser' => $user->display_name,
-        'logoutUrl'   => wp_logout_url()
+        'logoutUrl'   => wp_logout_url(),
+        'nonce'       => wp_create_nonce('wp_rest')
     ]);
 
     return ob_get_clean();

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -30,11 +30,12 @@ add_action('admin_menu', function() {
                 [],
                 $ver
             );
-            $user = wp_get_current_user();
+            $user  = wp_get_current_user();
             wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
                 'isPlugin'    => true,
                 'currentUser' => $user->display_name,
-                'logoutUrl'   => wp_logout_url()
+                'logoutUrl'   => wp_logout_url(),
+                'nonce'       => wp_create_nonce('wp_rest')
             ]);
 
         }

--- a/src/isPlugin.js
+++ b/src/isPlugin.js
@@ -1,5 +1,6 @@
 const globals = window.ReactDbGlobals || {};
 export const currentUser = globals.currentUser || '';
 export const logoutUrl = globals.logoutUrl || '';
+export const apiNonce = globals.nonce || '';
 const isPlugin = Boolean(globals.isPlugin);
 export default isPlugin;

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -9,14 +9,19 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import isPlugin from '../isPlugin';
+import isPlugin, { apiNonce } from '../isPlugin';
 
 const DatabaseManager = () => {
   const [rows, setRows] = useState([]);
 
   useEffect(() => {
     if (isPlugin) {
-      fetch('/wp-json/reactdb/v1/csv/read')
+      fetch('/wp-json/reactdb/v1/csv/read', {
+        credentials: 'include',
+        headers: {
+          'X-WP-Nonce': apiNonce
+        }
+      })
         .then((r) => {
           if (!r.ok) {
             if (r.status === 401) {

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -7,7 +7,7 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import isPlugin from '../isPlugin';
+import isPlugin, { apiNonce } from '../isPlugin';
 
 const Logs = () => {
   const [logs, setLogs] = useState([]);
@@ -15,7 +15,12 @@ const Logs = () => {
 
   useEffect(() => {
     if (isPlugin) {
-      fetch('/wp-json/reactdb/v1/logs')
+      fetch('/wp-json/reactdb/v1/logs', {
+        credentials: 'include',
+        headers: {
+          'X-WP-Nonce': apiNonce
+        }
+      })
         .then((r) => {
           if (!r.ok) {
             if (r.status === 401) {


### PR DESCRIPTION
## Summary
- localize REST nonce to the React app on admin and shortcode pages
- expose the nonce via `isPlugin.js`
- send the nonce and credentials in fetch calls

## Testing
- `npm test --silent`
- `CI=true npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68416f48e8d48323aa019cf4aa4bdcbc