### PR TITLE
Implement DB table creation and export

### DIFF
--- a/react-db-plugin/includes/api.php
+++ b/react-db-plugin/includes/api.php
@@ -34,4 +34,81 @@ add_action('rest_api_init', function () {
             return current_user_can('manage_options');
         }
     ]);
+
+    // --- Database management endpoints ---
+
+    register_rest_route('reactdb/v1', '/tables', [
+        'methods'  => 'GET',
+        'callback' => function () {
+            global $wpdb;
+            $prefix = $wpdb->prefix . 'reactdb_';
+            $tables = $wpdb->get_col($wpdb->prepare("SHOW TABLES LIKE %s", $wpdb->esc_like($prefix) . '%'));
+            $tables = array_map(function($t) use ($prefix) {
+                return substr($t, strlen($prefix));
+            }, $tables);
+            return $tables;
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
+
+    register_rest_route('reactdb/v1', '/table/create', [
+        'methods'  => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            global $wpdb;
+            $name = sanitize_key($request->get_param('name'));
+            if (!$name) {
+                return new WP_Error('invalid_name', 'Invalid table name', ['status' => 400]);
+            }
+            $table = $wpdb->prefix . 'reactdb_' . $name;
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table (id bigint(20) unsigned NOT NULL AUTO_INCREMENT, value text NOT NULL, PRIMARY KEY  (id)) $charset_collate";
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+            dbDelta($sql);
+            return ['status' => 'created'];
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
+
+    register_rest_route('reactdb/v1', '/table/export', [
+        'methods'  => 'GET',
+        'callback' => function (WP_REST_Request $request) {
+            global $wpdb;
+            $name = sanitize_key($request->get_param('name'));
+            $table = $wpdb->prefix . 'reactdb_' . $name;
+            if (!$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table))) {
+                return new WP_Error('invalid_table', 'Table not found', ['status' => 404]);
+            }
+            $rows = $wpdb->get_results("SELECT * FROM $table", ARRAY_A);
+            return $rows;
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
+
+    register_rest_route('reactdb/v1', '/table/copy', [
+        'methods'  => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            global $wpdb;
+            $name = sanitize_key($request->get_param('name'));
+            $id   = intval($request->get_param('id'));
+            $table = $wpdb->prefix . 'reactdb_' . $name;
+            if (!$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table))) {
+                return new WP_Error('invalid_table', 'Table not found', ['status' => 404]);
+            }
+            $row = $wpdb->get_row($wpdb->prepare("SELECT value FROM $table WHERE id = %d", $id), ARRAY_A);
+            if (!$row) {
+                return new WP_Error('invalid_row', 'Row not found', ['status' => 404]);
+            }
+            $wpdb->insert($table, ['value' => $row['value']]);
+            return ['status' => 'copied'];
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
 });

--- a/react-db-plugin/react-db-plugin.php
+++ b/react-db-plugin/react-db-plugin.php
@@ -8,39 +8,7 @@ Author: YourName
 
 defined('ABSPATH') || exit;
 
-add_action('admin_menu', function() {
-    add_menu_page(
-        'React DB App',
-        'React DB',
-        'manage_options',
-        'react-db-plugin',
-        function() {
-            echo '<div id="root"></div>';
-            $ver = file_exists(__DIR__ . '/assets/app.js') ? filemtime(__DIR__ . '/assets/app.js') : '1.0';
-            wp_enqueue_script(
-                'react-db-plugin-script',
-                plugins_url('assets/app.js', __FILE__),
-                [],
-                $ver,
-                true
-            );
-            wp_enqueue_style(
-                'react-db-plugin-style',
-                plugins_url('assets/app.css', __FILE__),
-                [],
-                $ver
-            );
-            $user  = wp_get_current_user();
-            wp_localize_script('react-db-plugin-script', 'ReactDbGlobals', [
-                'isPlugin'    => true,
-                'currentUser' => $user->display_name,
-                'logoutUrl'   => wp_logout_url(),
-                'nonce'       => wp_create_nonce('wp_rest')
-            ]);
-
-        }
-    );
-});
+// Admin menu entry removed -- the React app is now accessed via a dedicated page
 
 
 // REST APIを含める

--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -3,20 +3,26 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
 import isPlugin, { apiNonce } from '../isPlugin';
 
 const DatabaseManager = () => {
+  const [tables, setTables] = useState([]);
+  const [selected, setSelected] = useState('');
   const [rows, setRows] = useState([]);
+  const [newTable, setNewTable] = useState('');
 
   useEffect(() => {
     if (isPlugin) {
-      fetch('/wp-json/reactdb/v1/csv/read', {
+      fetch('/wp-json/reactdb/v1/tables', {
         credentials: 'include',
         headers: {
           'X-WP-Nonce': apiNonce
@@ -33,31 +39,80 @@ const DatabaseManager = () => {
         })
         .then((data) => {
           if (Array.isArray(data)) {
-            setRows(data);
+            setTables(data);
           } else {
             throw new Error('invalid data');
           }
         })
         .catch((err) => {
-          if (err.message === 'unauthorized') {
-            setRows([
-              ['Error'],
-              ['権限がありません']
-            ]);
-          } else {
-            setRows([
-              ['id', 'name'],
-              ['1', 'データ取得失敗']
-            ]);
-          }
+          console.error(err);
         });
     } else {
-      setRows([
-        ['id', 'name'],
-        ['1', 'デモデータ']
-      ]);
+      setTables(['demo_table']);
     }
   }, []);
+
+  const fetchRows = (table) => {
+    if (!table) return;
+    if (isPlugin) {
+      fetch(`/wp-json/reactdb/v1/table/export?name=${table}`, {
+        credentials: 'include',
+        headers: { 'X-WP-Nonce': apiNonce }
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          if (Array.isArray(data)) {
+            const header = data.length > 0 ? Object.keys(data[0]) : [];
+            const body = data.map((row) => Object.values(row));
+            setRows([header, ...body]);
+          } else {
+            setRows([]);
+          }
+        })
+        .catch(() => setRows([]));
+    } else {
+      setRows([
+        ['id', 'value'],
+        ['1', 'demo']
+      ]);
+    }
+  };
+
+  const handleCreate = () => {
+    if (!newTable) return;
+    fetch('/wp-json/reactdb/v1/table/create', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': apiNonce
+      },
+      body: JSON.stringify({ name: newTable })
+    })
+      .then(() => {
+        setNewTable('');
+        return fetch('/wp-json/reactdb/v1/tables', {
+          credentials: 'include',
+          headers: { 'X-WP-Nonce': apiNonce }
+        });
+      })
+      .then((r) => r.json())
+      .then((data) => setTables(Array.isArray(data) ? data : []))
+      .catch((e) => console.error(e));
+  };
+
+  const handleCopy = (id) => {
+    fetch('/wp-json/reactdb/v1/table/copy', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': apiNonce
+      },
+      body: JSON.stringify({ name: selected, id })
+    })
+      .then(() => fetchRows(selected));
+  };
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -66,8 +121,18 @@ const DatabaseManager = () => {
           テーブル一覧
         </Typography>
         <List dense>
-          <ListItem>{isPlugin ? 'wp_table' : 'sample_table'}</ListItem>
+          {tables.map((t) => (
+            <ListItem key={t} disablePadding>
+              <ListItemButton onClick={() => { setSelected(t); fetchRows(t); }}>
+                {t}
+              </ListItemButton>
+            </ListItem>
+          ))}
         </List>
+        <Box sx={{ mt: 2 }}>
+          <TextField size="small" label="新規テーブル" value={newTable} onChange={(e) => setNewTable(e.target.value)} />
+          <Button size="small" sx={{ ml: 1 }} variant="contained" onClick={handleCreate}>作成</Button>
+        </Box>
       </Box>
       <Box sx={{ flexGrow: 1 }}>
         <Typography variant="h6" gutterBottom>
@@ -80,6 +145,7 @@ const DatabaseManager = () => {
                 {rows[0]?.map((h, i) => (
                   <TableCell key={i}>{h}</TableCell>
                 ))}
+                {selected && <TableCell />}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -88,6 +154,11 @@ const DatabaseManager = () => {
                   {row.map((cell, j) => (
                     <TableCell key={j}>{cell}</TableCell>
                   ))}
+                  {selected && (
+                    <TableCell>
+                      <Button size="small" onClick={() => handleCopy(row[0])}>コピー</Button>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))}
             </TableBody>


### PR DESCRIPTION
## Summary
- remove admin menu entry from plugin
- add REST endpoints for table create/export/copy
- update DatabaseManager page with table creation and copy actions

## Testing
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68418ed264c88323a10d025ca18287f6