### PR TITLE
Implement database table creation and editing

### DIFF
--- a/react-db-plugin/includes/log-handler.php
+++ b/react-db-plugin/includes/log-handler.php
@@ -3,11 +3,27 @@ class LogHandler {
     public static function addLog($user_id, $action, $description) {
         global $wpdb;
         $table = $wpdb->prefix . 'reactdb_logs';
-        $wpdb->insert($table, [
-            'user_id' => $user_id,
-            'action' => $action,
-            'description' => $description,
-            'created_at' => current_time('mysql')
-        ]);
+        $last = $wpdb->get_var($wpdb->prepare(
+            "SELECT created_at FROM $table WHERE user_id = %d AND action = %s ORDER BY created_at DESC LIMIT 1",
+            $user_id,
+            $action
+        ));
+
+        $should_insert = true;
+        if ($last) {
+            $last_ts = strtotime($last);
+            if ($last_ts && $last_ts > current_time('timestamp') - 600) {
+                $should_insert = false;
+            }
+        }
+
+        if ($should_insert) {
+            $wpdb->insert($table, [
+                'user_id'    => $user_id,
+                'action'     => $action,
+                'description'=> $description,
+                'created_at' => current_time('mysql')
+            ]);
+        }
     }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,8 @@ import Layout from './components/Layout';
 import CSVImport from './pages/CSVImport';
 import CSVExport from './pages/CSVExport';
 import DatabaseManager from './pages/DatabaseManager';
+import TableCreate from './pages/TableCreate';
+import TableEditor from './pages/TableEditor';
 import Logs from './pages/Logs';
 
 function App() {
@@ -13,6 +15,8 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<DatabaseManager />} />
+          <Route path="/create" element={<TableCreate />} />
+          <Route path="/edit/:table/:id?" element={<TableEditor />} />
           <Route path="/import" element={<CSVImport />} />
           <Route path="/export" element={<CSVExport />} />
           <Route path="/logs" element={<Logs />} />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,6 +10,7 @@ import Toolbar from '@mui/material/Toolbar';
 const navItems = [
   { text: 'CSVインポート', to: '/import' },
   { text: 'CSVエクスポート', to: '/export' },
+  { text: 'DB登録', to: '/create' },
   { text: 'データベース一覧', to: '/' },
   { text: '操作ログ', to: '/logs' }
 ];

--- a/src/pages/TableEditor.js
+++ b/src/pages/TableEditor.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import isPlugin, { apiNonce } from '../isPlugin';
+
+const TableEditor = () => {
+  const { table, id } = useParams();
+  const navigate = useNavigate();
+  const [data, setData] = useState({});
+  const [columns, setColumns] = useState([]);
+
+  useEffect(() => {
+    if (!table) return;
+    if (isPlugin) {
+      fetch(`/wp-json/reactdb/v1/table/info?name=${table}`, { headers: { 'X-WP-Nonce': apiNonce }, credentials: 'include' })
+        .then(r => r.json())
+        .then(cols => setColumns(Array.isArray(cols) ? cols : []));
+      if (id) {
+        fetch(`/wp-json/reactdb/v1/table/row?name=${table}&id=${id}`, { headers: { 'X-WP-Nonce': apiNonce }, credentials: 'include' })
+          .then(r => r.json())
+          .then(row => setData(row));
+      }
+    }
+  }, [table, id]);
+
+  const handleChange = (field, value) => {
+    setData({ ...data, [field]: value });
+  };
+
+  const handleSave = () => {
+    const endpoint = id ? '/wp-json/reactdb/v1/table/update' : '/wp-json/reactdb/v1/table/addrow';
+    const body = id ? { name: table, id, data } : { name: table, data };
+    fetch(endpoint, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': apiNonce },
+      body: JSON.stringify(body),
+    }).then(() => navigate(`/`));
+  };
+
+  return (
+    <Box>
+      {columns.map((col) => (
+        col.Field !== 'id' && (
+          <TextField
+            key={col.Field}
+            label={col.Field}
+            value={data[col.Field] || ''}
+            onChange={(e) => handleChange(col.Field, e.target.value)}
+            sx={{ mb: 2, mr: 2 }}
+          />
+        )
+      ))}
+      <Button variant="contained" onClick={handleSave}>保存</Button>
+    </Box>
+  );
+};
+
+export default TableEditor;


### PR DESCRIPTION
## Summary
- add throttled logging to avoid duplicate entries
- expand table creation API to accept column definitions
- expose new endpoints for table info and row manipulation
- widen database list sidebar and support editing
- add TableCreate and TableEditor pages
- update routes and navigation

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bed7c08883239045d51f2e6667b8