### PR TITLE
Redirect new table creation

### DIFF
--- a/src/pages/DatabaseManager.js
+++ b/src/pages/DatabaseManager.js
@@ -92,25 +92,8 @@ const DatabaseManager = () => {
 
   const handleCreate = () => {
     if (!newTable) return;
-    fetch('/wp-json/reactdb/v1/table/create', {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-WP-Nonce': apiNonce
-      },
-      body: JSON.stringify({ name: newTable })
-    })
-      .then(() => {
-        setNewTable('');
-        return fetch('/wp-json/reactdb/v1/tables', {
-          credentials: 'include',
-          headers: { 'X-WP-Nonce': apiNonce }
-        });
-      })
-      .then((r) => r.json())
-      .then((data) => setTables(Array.isArray(data) ? data : []))
-      .catch((e) => console.error(e));
+    navigate(`/create?name=${encodeURIComponent(newTable)}`);
+    setNewTable('');
   };
 
   const handleCopy = () => {

--- a/src/pages/TableCreate.js
+++ b/src/pages/TableCreate.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
@@ -15,7 +15,8 @@ const typeOptions = [
 ];
 
 const TableCreate = () => {
-  const [name, setName] = useState('');
+  const [searchParams] = useSearchParams();
+  const [name, setName] = useState(searchParams.get('name') || '');
   const [columns, setColumns] = useState([{ name: '', type: 'TEXT', default: '' }]);
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary
- preserve table name when navigating to TableCreate
- allow TableCreate to read `name` from query

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842192ac52c8323bb9b1aad363f637c