### PR TITLE
Fix header overlap with WP admin bar

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,8 +5,13 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { currentUser, logoutUrl } from '../isPlugin';
 
-const Header = () => (
-  <AppBar position="fixed" color="default" sx={{ backgroundColor: '#fff' }}>
+const Header = ({ adminBarHeight = 0 }) => (
+  <AppBar
+    className="react-db-header"
+    position="fixed"
+    color="default"
+    sx={{ backgroundColor: '#fff', top: adminBarHeight }}
+  >
     <Toolbar>
       <Typography variant="h6" sx={{ flexGrow: 1 }}>
         React DB Manager

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,20 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Header from './Header';
 import Sidebar from './Sidebar';
 
-const Layout = ({ children }) => (
-  <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-    <Header />
-    <Box sx={{ display: 'flex', flexGrow: 1 }}>
-      <Sidebar />
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        <Toolbar />
-        {children}
+const Layout = ({ children }) => {
+  const [adminBarHeight, setAdminBarHeight] = useState(0);
+
+  useEffect(() => {
+    const bar = document.getElementById('wpadminbar');
+    if (!bar) return;
+
+    const handleResize = () => setAdminBarHeight(bar.offsetHeight);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Header adminBarHeight={adminBarHeight} />
+      <Box sx={{ display: 'flex', flexGrow: 1 }}>
+        <Sidebar adminBarHeight={adminBarHeight} />
+        <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+          <Toolbar sx={{ minHeight: `calc(64px + ${adminBarHeight}px)` }} />
+          {children}
+        </Box>
       </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
 export default Layout;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -17,7 +17,7 @@ const navItems = [
 
 const drawerWidth = 240;
 
-const Sidebar = () => (
+const Sidebar = ({ adminBarHeight = 0 }) => (
   <Drawer
     variant="permanent"
     sx={{
@@ -27,8 +27,8 @@ const Sidebar = () => (
         width: drawerWidth,
         boxSizing: 'border-box',
         backgroundColor: '#fff',
-        top: 64,
-        height: 'calc(100% - 64px)'
+        top: 64 + adminBarHeight,
+        height: `calc(100% - ${64 + adminBarHeight}px)`
       }
     }}
   >

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,13 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+body.admin-bar .react-db-header {
+  top: 32px;
+}
+
+@media (max-width: 782px) {
+  body.admin-bar .react-db-header {
+    top: 46px;
+  }
+}


### PR DESCRIPTION
## Summary
- detect WordPress admin bar height and pass it to the layout
- offset Header and Sidebar by the admin bar height
- add CSS rule for logged-in admin bar spacing

## Testing
- `npm test --silent` *(fails: No tests found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684224f1d4908323b4ad99576fae1594