### PR TITLE
Improve table editing and log display

### DIFF
--- a/react-db-plugin/includes/api.php
+++ b/react-db-plugin/includes/api.php
@@ -340,4 +340,21 @@ add_action('rest_api_init', function () {
             return current_user_can('manage_options');
         }
     ]);
+
+    register_rest_route('reactdb/v1', '/user/(?P<id>\d+)', [
+        'methods'  => 'GET',
+        'callback' => function (WP_REST_Request $request) {
+            $user = get_user_by('id', intval($request['id']));
+            if (!$user) {
+                return new WP_Error('invalid_user', 'User not found', ['status' => 404]);
+            }
+            return [
+                'id'   => $user->ID,
+                'name' => $user->user_login
+            ];
+        },
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
 });

--- a/src/pages/Logs.js
+++ b/src/pages/Logs.js
@@ -12,6 +12,7 @@ import isPlugin, { apiNonce } from '../isPlugin';
 const Logs = () => {
   const [logs, setLogs] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [userNames, setUserNames] = useState({});
 
   useEffect(() => {
     if (isPlugin) {
@@ -59,6 +60,21 @@ const Logs = () => {
     }
   }, []);
 
+  useEffect(() => {
+    const ids = logs.map((l) => l.user_id).filter((id) => id && !userNames[id]);
+    ids.forEach((id) => {
+      if (isPlugin) {
+        fetch(`/wp-json/reactdb/v1/user/${id}`, { headers: { 'X-WP-Nonce': apiNonce }, credentials: 'include' })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((u) => {
+            if (u && u.name) {
+              setUserNames((prev) => ({ ...prev, [id]: u.name }));
+            }
+          });
+      }
+    });
+  }, [logs]);
+
   if (loading) {
     return (
       <Box>
@@ -93,7 +109,7 @@ const Logs = () => {
               logs.map((log, i) => (
                 <TableRow key={i}>
                   <TableCell>{log.created_at}</TableCell>
-                  <TableCell>{log.user_id}</TableCell>
+                  <TableCell>{userNames[log.user_id] ? `${log.user_id}(${userNames[log.user_id]})` : log.user_id}</TableCell>
                   <TableCell>{log.action}</TableCell>
                   <TableCell>{log.description}</TableCell>
                 </TableRow>

--- a/src/pages/TableEditor.js
+++ b/src/pages/TableEditor.js
@@ -10,6 +10,14 @@ const TableEditor = () => {
   const navigate = useNavigate();
   const [data, setData] = useState({});
   const [columns, setColumns] = useState([]);
+  const [userNames, setUserNames] = useState({});
+
+  const isReadonly = (col) => {
+    const name = col.Field.toLowerCase();
+    if (col.Extra && col.Extra.includes('auto_increment')) return true;
+    if (col.Default === 'CURRENT_TIMESTAMP') return true;
+    return name === 'created_at' || name === 'updated_at';
+  };
 
   useEffect(() => {
     if (!table) return;
@@ -25,13 +33,32 @@ const TableEditor = () => {
     }
   }, [table, id]);
 
+  useEffect(() => {
+    const uid = data.user_id;
+    if (uid && isPlugin && !userNames[uid]) {
+      fetch(`/wp-json/reactdb/v1/user/${uid}`, { headers: { 'X-WP-Nonce': apiNonce }, credentials: 'include' })
+        .then(r => r.ok ? r.json() : null)
+        .then(u => {
+          if (u && u.name) {
+            setUserNames(prev => ({ ...prev, [uid]: u.name }));
+          }
+        });
+    }
+  }, [data.user_id]);
+
   const handleChange = (field, value) => {
     setData({ ...data, [field]: value });
   };
 
   const handleSave = () => {
     const endpoint = id ? '/wp-json/reactdb/v1/table/update' : '/wp-json/reactdb/v1/table/addrow';
-    const body = id ? { name: table, id, data } : { name: table, data };
+    const sanitized = { ...data };
+    columns.forEach(col => {
+      if (isReadonly(col)) {
+        delete sanitized[col.Field];
+      }
+    });
+    const body = id ? { name: table, id, data: sanitized } : { name: table, data: sanitized };
     fetch(endpoint, {
       method: 'POST',
       credentials: 'include',
@@ -52,13 +79,18 @@ const TableEditor = () => {
     <Box>
       {columns.map((col) => (
         col.Field !== 'id' && (
-          <TextField
-            key={col.Field}
-            label={col.Field}
-            value={data[col.Field] || ''}
-            onChange={(e) => handleChange(col.Field, e.target.value)}
-            sx={{ mb: 2, mr: 2 }}
-          />
+          <Box key={col.Field} sx={{ display: 'flex', alignItems: 'center', mb: 2, mr: 2 }}>
+            <TextField
+              label={col.Field}
+              value={data[col.Field] || ''}
+              onChange={(e) => handleChange(col.Field, e.target.value)}
+              sx={{ mr: 1 }}
+              InputProps={{ readOnly: isReadonly(col) }}
+            />
+            {col.Field === 'user_id' && userNames[data[col.Field]] && (
+              <span>({userNames[data[col.Field]]})</span>
+            )}
+          </Box>
         )
       ))}
       <Button variant="contained" onClick={handleSave} sx={{ mr: 2 }}>保存</Button>


### PR DESCRIPTION
## Summary
- prevent editing of automatically generated columns in the table editor
- show the username next to numeric `user_id`
- add REST API route to fetch user information

## Testing
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68422ab0f4308323a76cadd761ce0301