### PR TITLE
Handle timestamp auto fields

### DIFF
--- a/src/pages/TableEditor.js
+++ b/src/pages/TableEditor.js
@@ -14,7 +14,12 @@ const TableEditor = () => {
 
   const isReadonly = (col) => {
     const name = col.Field.toLowerCase();
-    if (col.Extra && col.Extra.includes('auto_increment')) return true;
+    const extra = (col.Extra || '').toLowerCase();
+    const def = (col.Default || '').toString().toLowerCase();
+    const type = (col.Type || '').toLowerCase();
+    if (extra.includes('auto_increment')) return true;
+    if (type.includes('timestamp') && (def.includes('current_timestamp') || extra.includes('current_timestamp')))
+      return true;
     if (col.Default === 'CURRENT_TIMESTAMP') return true;
     return name === 'created_at' || name === 'updated_at';
   };


### PR DESCRIPTION
## Summary
- prevent editing timestamp columns with automatic values when adding or editing rows

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422fcfc74c8323a5a88f582d7aa597