### PR TITLE
Handle timestamps and hide log fields

### DIFF
--- a/react-db-plugin/includes/api.php
+++ b/react-db-plugin/includes/api.php
@@ -291,6 +291,10 @@ add_action('rest_api_init', function () {
             if (!$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table))) {
                 return new WP_Error('invalid_table', 'Table not found', ['status' => 404]);
             }
+            $columns = $wpdb->get_col("DESC $table", 0);
+            if (in_array('updated_at', $columns, true)) {
+                $data['updated_at'] = current_time('mysql');
+            }
             $wpdb->update($table, $data, ['id' => $id]);
             LogHandler::addLog(get_current_user_id(), 'Update Row', $name);
             return ['status' => 'updated'];
@@ -312,6 +316,13 @@ add_action('rest_api_init', function () {
             $table = $wpdb->prefix . 'reactdb_' . $name;
             if (!$wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table))) {
                 return new WP_Error('invalid_table', 'Table not found', ['status' => 404]);
+            }
+            $columns = $wpdb->get_col("DESC $table", 0);
+            if (in_array('created_at', $columns, true) && empty($data['created_at'])) {
+                $data['created_at'] = current_time('mysql');
+            }
+            if (in_array('updated_at', $columns, true) && empty($data['updated_at'])) {
+                $data['updated_at'] = current_time('mysql');
             }
             $wpdb->insert($table, $data);
             LogHandler::addLog(get_current_user_id(), 'Insert Row', $name);

--- a/src/pages/TableEditor.js
+++ b/src/pages/TableEditor.js
@@ -24,6 +24,11 @@ const TableEditor = () => {
     return name === 'created_at' || name === 'updated_at';
   };
 
+  const isHidden = (col) => {
+    const name = col.Field.toLowerCase();
+    return name === 'created_at' || name === 'updated_at';
+  };
+
   useEffect(() => {
     if (!table) return;
     if (isPlugin) {
@@ -82,13 +87,12 @@ const TableEditor = () => {
   };
   return (
     <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
-      {columns.map((col) => (
-        col.Field !== 'id' && (
-          <React.Fragment key={col.Field}>
-            <TextField
-              label={col.Field}
-              value={data[col.Field] || ''}
-              onChange={(e) => handleChange(col.Field, e.target.value)}
+      {columns.filter(col => col.Field !== 'id' && !isHidden(col)).map((col) => (
+        <React.Fragment key={col.Field}>
+          <TextField
+            label={col.Field}
+            value={data[col.Field] || ''}
+            onChange={(e) => handleChange(col.Field, e.target.value)}
               sx={{ mb: 2, mr: 1 }}
               InputProps={{ readOnly: isReadonly(col) }}
             />


### PR DESCRIPTION
## Summary
- handle `created_at` and `updated_at` automatically on row insert/update
- hide timestamp fields when editing tables

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842320dfae08323b740b8c659ddd81f