### PR TITLE
Improve output task configuration

### DIFF
--- a/react-db-plugin/includes/output-handler.php
+++ b/react-db-plugin/includes/output-handler.php
@@ -11,9 +11,15 @@ class OutputHandler {
     }
 
     public static function update_settings($settings) {
-        if (is_array($settings)) {
-            update_option('reactdb_output_settings', $settings);
+        if (!is_array($settings)) {
+            return;
         }
+        foreach ($settings as $task => $conf) {
+            if (isset($conf['html'])) {
+                $settings[$task]['html'] = wp_kses_post($conf['html']);
+            }
+        }
+        update_option('reactdb_output_settings', $settings);
     }
 
     public static function get_rows($table) {
@@ -29,6 +35,9 @@ class OutputHandler {
         $config = self::get_task($task);
         if (!$config) {
             return '<div>No settings</div>';
+        }
+        if (!empty($config['html'])) {
+            return $config['html'];
         }
         $rows = self::get_rows($config['table']);
         if (!$rows) {
@@ -48,9 +57,8 @@ class OutputHandler {
         if (!$config) {
             return new WP_Error('not_found', 'Task not found', ['status' => 404]);
         }
-        $rows = self::get_rows($config['table']);
         if ($config['format'] === 'json') {
-            return $rows;
+            return self::get_rows($config['table']);
         }
         return ['html' => self::render_html($task)];
     }

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import TableCreate from './pages/TableCreate';
 import TableEditor from './pages/TableEditor';
 import Logs from './pages/Logs';
 import OutputSettings from './pages/OutputSettings';
+import OutputTask from './pages/OutputTask';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
           <Route path="/export" element={<CSVExport />} />
           <Route path="/logs" element={<Logs />} />
           <Route path="/output" element={<OutputSettings />} />
+          <Route path="/output/:task" element={<OutputTask />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Layout>


### PR DESCRIPTION
## Summary
- allow storing HTML per output task on backend
- link to per-task configuration from output settings
- show endpoint or HTML editor when editing a task

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424b8287a48323a7fea25f3ae300cb