### PR TITLE
Add instructions for output API

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,19 @@ CSVのインポートでは最初の100行を解析し、各カラムの値に�
 [reactdb input='DB:"c1",sample']
 ```
 
+## 出力API
+
+プラグインで設定したタスクのデータは REST API から取得できます。
+`/wp-json/reactdb/v1/output/<タスク名>` に GET リクエストを
+送信してください。
+
+```bash
+curl -X GET https://example.com/wp-json/reactdb/v1/output/testAPI-JSON
+```
+
+上記の例では `testAPI-JSON` タスクで定義されたテーブル内容が
+JSON 形式で返されます。
+
 ## 開発メモ
 
 - Reactのソースコードは`src/`に配置されています。

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ database table. Both accept an `input` attribute formatted as
 [reactdb input='DB:"c1",sample']
 ```
 
+## Output API
+
+Data configured with the plugin can be fetched directly via a REST
+endpoint. Send a GET request to `/wp-json/reactdb/v1/output/<task>`
+where `<task>` is the name of the output definition.
+
+```bash
+curl -X GET https://example.com/wp-json/reactdb/v1/output/testAPI-JSON
+```
+
+The endpoint returns a JSON array of rows or an HTML snippet depending on
+the task settings.
+
 ## Development Notes
 
 - React source files live under `src/`.


### PR DESCRIPTION
## Summary
- document how to fetch output via the `/output` REST endpoint
- add the same section in both English and Japanese README files

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424d64c1788323916015497e2333f2