### PR TITLE
Add template hints for output tasks

### DIFF
--- a/react-db-plugin/includes/output-handler.php
+++ b/react-db-plugin/includes/output-handler.php
@@ -36,12 +36,20 @@ class OutputHandler {
         if (!$config) {
             return '<div>No settings</div>';
         }
-        if (!empty($config['html'])) {
-            return $config['html'];
-        }
         $rows = self::get_rows($config['table']);
         if (!$rows) {
             return '<div>No data</div>';
+        }
+        if (!empty($config['html'])) {
+            ob_start();
+            foreach ($rows as $row) {
+                $html = $config['html'];
+                foreach ($row as $k => $v) {
+                    $html = str_replace('{{' . $k . '}}', esc_html($v), $html);
+                }
+                echo $html;
+            }
+            return ob_get_clean();
         }
         ob_start();
         echo '<ul class="reactdb-output-list">';


### PR DESCRIPTION
## Summary
- auto-build a placeholder HTML snippet based on table columns when setting up a task
- display shortcode under the save button for easy copy
- allow placeholders like `{{column}}` to be replaced when rendering HTML output

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684250b524b48323a2a4c479ed80a809