### PR TITLE
Add preview and delete options

### DIFF
--- a/src/components/HTMLPreview.js
+++ b/src/components/HTMLPreview.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+const HTMLPreview = ({ html, data }) => {
+  const renderHTML = (template, values) => {
+    if (!template) return '';
+    let rendered = template;
+    Object.keys(values || {}).forEach(key => {
+      const regex = new RegExp(`{{${key}}}`, 'g');
+      rendered = rendered.replace(regex, values[key]);
+    });
+    return rendered;
+  };
+
+  return (
+    <Box sx={{ border: '1px solid #ddd', p: 2, borderRadius: 2, ml: 4, flex: 1 }}>
+      <Typography variant="h6" gutterBottom>プレビュー</Typography>
+      <Box dangerouslySetInnerHTML={{ __html: renderHTML(html, data) }} />
+    </Box>
+  );
+};
+
+export default HTMLPreview;

--- a/src/pages/OutputSettings.js
+++ b/src/pages/OutputSettings.js
@@ -14,6 +14,23 @@ const OutputSettings = () => {
   const [format, setFormat] = useState('html');
   const [tables, setTables] = useState([]);
 
+  const deleteTask = (name) => {
+    const newSettings = { ...settings };
+    delete newSettings[name];
+    if (isPlugin) {
+      fetch('/wp-json/reactdb/v1/output/settings', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': apiNonce },
+        body: JSON.stringify({ settings: newSettings })
+      })
+        .then(r => r.json())
+        .then(data => setSettings(data));
+    } else {
+      setSettings(newSettings);
+    }
+  };
+
   useEffect(() => {
     if (isPlugin) {
       fetch('/wp-json/reactdb/v1/output/settings', {
@@ -69,8 +86,11 @@ const OutputSettings = () => {
       <Box>
         {Object.keys(settings).length === 0 && <div>設定なし</div>}
         {Object.entries(settings).map(([name, conf]) => (
-          <Box key={name}>
+          <Box key={name} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Link to={`/output/${name}`}>{name}</Link>: {conf.table} ({conf.format})
+            <Button size="small" color="error" onClick={() => deleteTask(name)}>
+              削除
+            </Button>
           </Box>
         ))}
       </Box>


### PR DESCRIPTION
## Summary
- fetch first row from table and show HTML preview with real data
- add delete button on single task page
- allow deleting tasks from list page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425ec15db083239519ff520add61b0