### PR TITLE
Improve CSV import robustness and add preview UI

### DIFF
--- a/react-db-plugin/includes/csv-handler.php
+++ b/react-db-plugin/includes/csv-handler.php
@@ -1,14 +1,137 @@
 <?php
 class CSVHandler {
+    /**
+     * Read CSV file with automatic encoding, delimiter and BOM handling.
+     */
     public static function readCSV($filepath) {
-        $rows = [];
-        if (($handle = fopen($filepath, 'r')) !== FALSE) {
-            while (($data = fgetcsv($handle)) !== FALSE) {
-                $rows[] = $data;
-            }
-            fclose($handle);
+        $parsed = self::parseCSV($filepath);
+        return $parsed['rows'];
+    }
+
+    /**
+     * Parse a CSV file and return rows with metadata.
+     *
+     * @param string $filepath
+     * @param array  $args
+     * @return array{rows: array<int, array<int, string>>, delimiter: string|null, encoding: string|null}
+     */
+    public static function parseCSV($filepath, $args = []) {
+        $defaults = [
+            'skip_empty' => true,
+        ];
+        if (function_exists('wp_parse_args')) {
+            $args = wp_parse_args($args, $defaults);
+        } else {
+            $args = array_merge($defaults, is_array($args) ? $args : []);
         }
-        return $rows;
+
+        if (!is_readable($filepath)) {
+            return [
+                'rows'      => [],
+                'delimiter' => null,
+                'encoding'  => null,
+            ];
+        }
+
+        $contents = file_get_contents($filepath);
+        if ($contents === false) {
+            return [
+                'rows'      => [],
+                'delimiter' => null,
+                'encoding'  => null,
+            ];
+        }
+
+        $encoding = null;
+        if (function_exists('mb_detect_encoding')) {
+            $encoding = mb_detect_encoding($contents, ['UTF-8', 'SJIS-win', 'eucJP-win', 'EUC-JP', 'JIS', 'ISO-2022-JP', 'ISO-8859-1', 'CP932'], true);
+        }
+
+        if ($encoding && strtoupper($encoding) !== 'UTF-8' && function_exists('mb_convert_encoding')) {
+            $converted = mb_convert_encoding($contents, 'UTF-8', $encoding);
+            if ($converted !== false) {
+                $contents = $converted;
+            } else {
+                $encoding = 'UTF-8';
+            }
+        } else {
+            $encoding = 'UTF-8';
+        }
+
+        // Remove BOM if present.
+        if (strncmp($contents, "\xEF\xBB\xBF", 3) === 0) {
+            $contents = substr($contents, 3);
+        }
+
+        // Normalise line endings.
+        $contents = preg_replace("/\r\n?|\n/", "\n", $contents);
+
+        $lines = preg_split("/\n/", $contents);
+        $sampleLine = '';
+        foreach ($lines as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            $sampleLine = $line;
+            break;
+        }
+
+        $delimiter = ',';
+        if ($sampleLine !== '') {
+            $delimiters = [',', "\t", ';', '|'];
+            $bestCount  = 0;
+            foreach ($delimiters as $candidate) {
+                $count = substr_count($sampleLine, $candidate);
+                if ($count > $bestCount) {
+                    $bestCount = $count;
+                    $delimiter = $candidate;
+                }
+            }
+        }
+
+        $temp = fopen('php://temp', 'r+');
+        fwrite($temp, implode("\n", $lines));
+        fwrite($temp, "\n");
+        rewind($temp);
+
+        $rows = [];
+        if (function_exists('ini_set')) {
+            @ini_set('auto_detect_line_endings', '1');
+        }
+
+        while (($data = fgetcsv($temp, 0, $delimiter)) !== false) {
+            if ($data === null) {
+                continue;
+            }
+
+            // Trim whitespace and normalise nulls to empty strings.
+            foreach ($data as $index => $value) {
+                if ($value === null) {
+                    $data[$index] = '';
+                } else {
+                    $data[$index] = is_string($value) ? trim($value) : $value;
+                }
+            }
+
+            if ($args['skip_empty']) {
+                $nonEmpty = array_filter($data, function ($item) {
+                    return $item !== '' && $item !== null;
+                });
+                if (empty($nonEmpty)) {
+                    continue;
+                }
+            }
+
+            $rows[] = $data;
+        }
+
+        fclose($temp);
+
+        return [
+            'rows'      => $rows,
+            'delimiter' => $delimiter,
+            'encoding'  => $encoding,
+        ];
     }
 
     public static function writeCSV($filepath, $data) {

--- a/src/pages/CSVImport.js
+++ b/src/pages/CSVImport.js
@@ -7,6 +7,12 @@ import TextField from '@mui/material/TextField';
 import Alert from '@mui/material/Alert';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import isPlugin, { apiNonce, apiEndpoint } from '../isPlugin';
 
 const normalizeOverride = (value) => {
@@ -28,6 +34,7 @@ const CSVImport = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pendingColumns, setPendingColumns] = useState([]);
   const [overrides, setOverrides] = useState({});
+  const [preview, setPreview] = useState(null);
 
   const resetOverrides = () => {
     setPendingColumns([]);
@@ -40,6 +47,7 @@ const CSVImport = () => {
     setLog('');
     setLogSeverity('info');
     resetOverrides();
+    setPreview(null);
   };
 
   const submitImport = async (overridePayload = null) => {
@@ -66,6 +74,7 @@ const CSVImport = () => {
     setIsSubmitting(true);
     setLog('');
     setLogSeverity('info');
+    setPreview(null);
 
     try {
       const response = await fetch(apiEndpoint('table/import'), {
@@ -95,9 +104,11 @@ const CSVImport = () => {
       setLogSeverity('success');
       setLog('インポートに成功しました。');
       resetOverrides();
+      setPreview(data?.preview || null);
     } catch (error) {
       setLogSeverity('error');
       setLog(error.message || 'インポートに失敗しました。');
+      setPreview(null);
     } finally {
       setIsSubmitting(false);
     }
@@ -138,6 +149,62 @@ const CSVImport = () => {
       return !value || !isValidOverride(value);
     });
   }, [pendingColumns, overrides]);
+
+  const delimiterLabel = useMemo(() => {
+    if (!preview || !preview.delimiter) {
+      return '自動判定不可';
+    }
+    switch (preview.delimiter) {
+      case '\t':
+        return 'タブ (\\t)';
+      case ';':
+        return 'セミコロン (;)';
+      case '|':
+        return 'パイプ (|)';
+      case ',':
+        return 'カンマ (,)';
+      default:
+        return preview.delimiter;
+    }
+  }, [preview]);
+
+  const encodingLabel = useMemo(() => {
+    if (!preview || !preview.encoding) {
+      return '不明';
+    }
+    return preview.encoding;
+  }, [preview]);
+
+  const previewRows = useMemo(
+    () => (preview && Array.isArray(preview.rows) ? preview.rows : []),
+    [preview]
+  );
+
+  const totalRowsLabel = useMemo(() => {
+    if (!preview || typeof preview.total_rows !== 'number') {
+      return previewRows.length;
+    }
+    return preview.total_rows;
+  }, [preview, previewRows]);
+
+  const sourceRowsLabel = useMemo(() => {
+    if (!preview || typeof preview.source_rows !== 'number') {
+      return totalRowsLabel;
+    }
+    return preview.source_rows;
+  }, [preview, totalRowsLabel]);
+
+  const failedRowsLabel = useMemo(() => {
+    if (!preview || typeof preview.failed_rows !== 'number') {
+      return 0;
+    }
+    return preview.failed_rows;
+  }, [preview]);
+
+  const failedSamples = useMemo(
+    () => (preview && Array.isArray(preview.failed_samples) ? preview.failed_samples : []),
+    [preview]
+  );
 
   return (
     <Box>
@@ -205,6 +272,96 @@ const CSVImport = () => {
         <Alert severity={logSeverity} sx={{ mt: 3 }}>
           {log}
         </Alert>
+      )}
+
+      {preview && (
+        <Paper variant="outlined" sx={{ mt: 3, p: 3 }}>
+          <Stack spacing={2}>
+            <Box>
+              <Typography variant="h6">インポートプレビュー</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {`元データ${sourceRowsLabel}件中${totalRowsLabel}件を登録しました。`}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {`判定された区切り文字: ${delimiterLabel}, 文字コード: ${encodingLabel}`}
+              </Typography>
+            </Box>
+
+            {Array.isArray(preview.columns) &&
+              preview.columns.some((col) => col.auto_generated || col.override_used || col.original !== col.sanitized_value) && (
+              <Alert severity="info">
+                自動的に使用可能なカラム名へ変換しています。プレビューの見出しと括弧内の英字が実際のカラム名です。
+              </Alert>
+            )}
+
+            {failedRowsLabel > 0 && (
+              <Alert severity="warning">
+                <Stack spacing={1}>
+                  <Typography variant="body2">
+                    {`一部の行 (${failedRowsLabel}件) はデータベースに保存できなかったためスキップしました。`}
+                  </Typography>
+                  {failedSamples.length > 0 && (
+                    <Box
+                      sx={{
+                        maxHeight: 180,
+                        overflow: 'auto',
+                        p: 1,
+                        bgcolor: (theme) => theme.palette.action.hover,
+                        borderRadius: 1,
+                      }}
+                    >
+                      <Typography component="pre" variant="caption" sx={{ m: 0, whiteSpace: 'pre-wrap' }}>
+                        {JSON.stringify(failedSamples, null, 2)}
+                      </Typography>
+                    </Box>
+                  )}
+                </Stack>
+              </Alert>
+            )}
+
+            <TableContainer sx={{ maxHeight: 360 }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    {Array.isArray(preview.columns) &&
+                      preview.columns.map((col) => (
+                        <TableCell key={col.key} sx={{ whiteSpace: 'nowrap' }}>
+                          <Typography variant="subtitle2">{col.label}</Typography>
+                          {col.sanitized_value && col.sanitized_value !== col.label && (
+                            <Typography variant="caption" color="text.secondary">
+                              {`(${col.sanitized_value})`}
+                            </Typography>
+                          )}
+                        </TableCell>
+                      ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {previewRows.length > 0 && Array.isArray(preview.columns) &&
+                    previewRows.map((row, rowIndex) => (
+                      <TableRow key={rowIndex} hover>
+                        {preview.columns.map((col) => (
+                          <TableCell key={col.key}>
+                            {row[col.key] !== undefined && row[col.key] !== null ? row[col.key] : ''}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  {previewRows.length === 0 && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={Array.isArray(preview.columns) ? preview.columns.length : 1}
+                        align="center"
+                      >
+                        表示できる行がありません。
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Stack>
+        </Paper>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary
- enhance the PHP CSV parser to auto-detect encoding/delimiters, normalise data and expose metadata for downstream logic
- rework the table import REST endpoint to auto-sanitise column names, tolerate ambiguous headers, capture failures and return preview details
- update the React CSV import page to surface the server-provided preview, delimiter/encoding info and warnings for skipped rows

## Testing
- npm run build
- php -l react-db-plugin/includes/csv-handler.php
- php -l react-db-plugin/includes/api.php

------
https://chatgpt.com/codex/tasks/task_e_68e4c9de20dc8323a14117ce85d31635