### PR TITLE
Improve CSV recovery heuristics for quoted fields

### DIFF
--- a/react-db-plugin/includes/csv-handler.php
+++ b/react-db-plugin/includes/csv-handler.php
@@ -384,7 +384,8 @@ class CSVHandler {
             return false;
         }
 
-        if (strpos($trimmed, $delimiter) === false) {
+        $delimiterPos = strpos($trimmed, $delimiter);
+        if ($delimiterPos === false) {
             return false;
         }
 
@@ -409,6 +410,11 @@ class CSVHandler {
                     }
                 }
             }
+            return false;
+        }
+
+        $firstField = substr($trimmed, 0, $delimiterPos);
+        if (substr_count($firstField, '"') % 2 !== 0) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
- refine the CSV row lookahead logic to guard against misidentifying multiline quoted fields as new rows
- ensure fields with unmatched quotes are not treated as new rows during recovery heuristics

## Testing
- php -l react-db-plugin/includes/csv-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e4e36d1d9c83239dbafc77292d7596