### PR TITLE
Add configurable CSS to output tasks

### DIFF
--- a/react-db-plugin/includes/output-handler.php
+++ b/react-db-plugin/includes/output-handler.php
@@ -18,6 +18,11 @@ class OutputHandler {
             if (isset($conf['html'])) {
                 $settings[$task]['html'] = wp_kses_post($conf['html']);
             }
+            if (isset($conf['css'])) {
+                $settings[$task]['css'] = wp_strip_all_tags(is_string($conf['css']) ? $conf['css'] : '');
+            } elseif (!isset($settings[$task]['css'])) {
+                $settings[$task]['css'] = '';
+            }
         }
         update_option('reactdb_output_settings', $settings);
     }
@@ -40,8 +45,12 @@ class OutputHandler {
         if (!$rows) {
             return '<div>No data</div>';
         }
+        $css = !empty($config['css']) ? trim($config['css']) : '';
         if (!empty($config['html'])) {
             ob_start();
+            if ($css !== '') {
+                echo '<style>' . $css . '</style>';
+            }
             foreach ($rows as $row) {
                 $html = $config['html'];
                 foreach ($row as $k => $v) {
@@ -52,6 +61,9 @@ class OutputHandler {
             return ob_get_clean();
         }
         ob_start();
+        if ($css !== '') {
+            echo '<style>' . $css . '</style>';
+        }
         echo '<ul class="reactdb-output-list">';
         foreach ($rows as $row) {
             echo '<li>' . esc_html(join(' | ', $row)) . '</li>';

--- a/src/components/HTMLPreview.js
+++ b/src/components/HTMLPreview.js
@@ -2,21 +2,24 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 
-const HTMLPreview = ({ html, data }) => {
-  const renderHTML = (template, values) => {
-    if (!template) return '';
-    let rendered = template;
+const HTMLPreview = ({ html, css, data }) => {
+  const renderHTML = (template, values, cssText) => {
+    const hasTemplate = !!template;
+    const hasCss = !!cssText;
+    if (!hasTemplate && !hasCss) return '';
+    let rendered = template || '';
     Object.keys(values || {}).forEach(key => {
       const regex = new RegExp(`{{${key}}}`, 'g');
       rendered = rendered.replace(regex, values[key]);
     });
-    return rendered;
+    const cssBlock = hasCss ? `<style>${cssText}</style>` : '';
+    return cssBlock + rendered;
   };
 
   return (
     <Box sx={{ border: '1px solid #ddd', p: 2, borderRadius: 2, ml: 4, flex: 1 }}>
       <Typography variant="h6" gutterBottom>プレビュー</Typography>
-      <Box dangerouslySetInnerHTML={{ __html: renderHTML(html, data) }} />
+      <Box dangerouslySetInnerHTML={{ __html: renderHTML(html, data, css) }} />
     </Box>
   );
 };

--- a/src/pages/OutputSettings.js
+++ b/src/pages/OutputSettings.js
@@ -52,7 +52,7 @@ const OutputSettings = () => {
 
   const handleSave = () => {
     if (!task || !table) return;
-    const newSettings = { ...settings, [task]: { table, format, html: '' } };
+    const newSettings = { ...settings, [task]: { table, format, html: '', css: '' } };
     if (isPlugin) {
       fetch(apiEndpoint('output/settings'), {
         method: 'POST',


### PR DESCRIPTION
## Summary
- allow administrators to save custom CSS alongside HTML output templates
- inject CSS only once during output rendering to avoid repetition and update the preview UI to support it

## Testing
- not run (react-scripts not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4e8a407588323b9e8209204bcbd91